### PR TITLE
Create gpuexec.h for gpu processing (Used, if OpenGL is too big)

### DIFF
--- a/include/gpuexec.h
+++ b/include/gpuexec.h
@@ -1,0 +1,10 @@
+namespace PL
+{
+  namespace GPU
+  {
+    class gpuexec
+    {
+    
+    };
+  }
+}


### PR DESCRIPTION
This is used for only GLSL, without OpenGL for smaller file size and faster execution